### PR TITLE
Iter23

### DIFF
--- a/integration_tests/url_handler_integration_test.go
+++ b/integration_tests/url_handler_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -63,7 +64,7 @@ func (s *IntegrationTestSuite) SetupTest() {
 	if err != nil {
 		logger.Error("Unable to get endpoint", zap.Error(err))
 	}
-	s.urlHandler = handlers.NewURLHandler(s.echo, s.urlService, s.endpoint, jwtManager, logger)
+	s.urlHandler = handlers.NewURLHandler(s.echo, s.urlService, s.endpoint, jwtManager, logger, &sync.WaitGroup{})
 }
 
 func (s *IntegrationTestSuite) TestAddURL() {

--- a/internal/app/shortener/app.go
+++ b/internal/app/shortener/app.go
@@ -29,11 +29,13 @@ import (
 //
 // It does not take any parameters and does not return any values.
 func URLShortenerRun() {
-	cfg := *config.NewConfig()
 	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatal("Unable to initialize zap logger", zap.Error(err))
 	}
+
+	cfg := *config.NewConfig(logger)
+
 	jwtManager := jwtgen.InitJWTManager(cfg.TokenName, cfg.SecretKey, logger)
 	repository := initRepository(&cfg, logger)
 	urlService := service.NewURLService(repository, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	RepositoryType  Repository
 	SecretKey       string
 	TokenName       string
+	EnableHTTPS     string
 }
 
 // NewConfig creates a new Config instance with default values and returns a pointer to it.
@@ -59,7 +60,10 @@ func (c *Config) parseFlags() {
 	flag.StringVar(&DataBaseDSN, "d", "", "Enter url to connect database as host=host port=port user=postgres password=postgres dbname=dbname sslmode=disable Or use DATABASE_DSN env")
 
 	var SecretKey string
-	flag.StringVar(&SecretKey, "s", "supersecretkey", "Enter secret key Or use SECRET_KEY env")
+	flag.StringVar(&SecretKey, "k", "supersecretkey", "Enter secret key Or use SECRET_KEY env")
+
+	var EnableHTTPS string
+	flag.StringVar(&EnableHTTPS, "s", "false", "Enable HTTPS Or use ENABLE_HTTPS env")
 
 	var TokenName string
 	flag.StringVar(&TokenName, "t", "token", "Enter token name Or use TOKEN_NAME env")
@@ -71,6 +75,7 @@ func (c *Config) parseFlags() {
 	c.FileStoragePath = FileStoragePath
 	c.DataBaseDSN = DataBaseDSN
 	c.SecretKey = SecretKey
+	c.EnableHTTPS = EnableHTTPS
 	c.TokenName = TokenName
 }
 
@@ -93,6 +98,10 @@ func (c *Config) parseEnv() {
 
 	if envSecretKey := os.Getenv("SECRET_KEY"); envSecretKey != "" {
 		c.SecretKey = envSecretKey
+	}
+
+	if envEnableHTTPS := os.Getenv("ENABLE_HTTPS"); envEnableHTTPS != "" {
+		c.EnableHTTPS = envEnableHTTPS
 	}
 
 	if envTokenName := os.Getenv("TOKEN_NAME"); envTokenName != "" {

--- a/internal/handlers/example_test.go
+++ b/internal/handlers/example_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
@@ -40,7 +41,7 @@ func ExampleURLHandler_AddURL() {
 
 	e := echo.New()
 	echopprof.Wrap(e)
-	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger)
+	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 
 	request := httptest.NewRequest(http.MethodPost, "http://localhost:8080/", strings.NewReader("https://example.com"))
 	w := httptest.NewRecorder()
@@ -68,7 +69,7 @@ func ExampleURLHandler_FindAllURLByUserID() {
 
 	e := echo.New()
 	echopprof.Wrap(e)
-	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger)
+	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 
 	request := httptest.NewRequest(http.MethodGet, "http://localhost:8080/api/user/urls", strings.NewReader(""))
 	w := httptest.NewRecorder()
@@ -97,7 +98,7 @@ func ExampleURLHandler_AddBatch() {
 
 	e := echo.New()
 	echopprof.Wrap(e)
-	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger)
+	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 
 	fullURL1 := dto.URLBatchRequest{
 		CorrelationID: "2d5d144a-f272-40d3-b3aa-d4b1b9da277c",
@@ -142,7 +143,7 @@ func ExampleURLHandler_FindAll() {
 
 	e := echo.New()
 	echopprof.Wrap(e)
-	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger)
+	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 
 	fullURL1 := dto.URLBatchRequest{
 		CorrelationID: "2d5d144a-f272-40d3-b3aa-d4b1b9da277c",
@@ -182,7 +183,7 @@ func ExampleURLHandler_FindURL() {
 
 	e := echo.New()
 	echopprof.Wrap(e)
-	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger)
+	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 
 	urlService.Add(context.Background(), "https://example.com", "localhost:8080", "token")
 
@@ -209,7 +210,7 @@ func ExampleURLHandler_AddShorten() {
 
 	e := echo.New()
 	echopprof.Wrap(e)
-	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger)
+	h := NewURLHandler(e, urlService, cfg.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 
 	requestBody := dto.URLRequest{URL: "https://example.com"}
 	body, _ := json.Marshal(requestBody)

--- a/internal/handlers/url_handler_test.go
+++ b/internal/handlers/url_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/msmkdenis/yap-shortener/internal/dto"
@@ -51,7 +52,7 @@ func (s *URLHandlerTestSuite) SetupTest() {
 	s.ctrl = gomock.NewController(s.T())
 	s.echo = echo.New()
 	s.urlService = mock.NewMockURLService(s.ctrl)
-	s.h = NewURLHandler(s.echo, s.urlService, cfgMock.URLPrefix, jwtManager, logger)
+	s.h = NewURLHandler(s.echo, s.urlService, cfgMock.URLPrefix, jwtManager, logger, &sync.WaitGroup{})
 }
 
 func (s *URLHandlerTestSuite) TestDeleteAllURLsByUserID_Unauthorized() {


### PR DESCRIPTION
**Инкремент 21:**
Добавил запуск HTTPS сервера по флагу -s.
https://github.com/msmkdenis/yap-shortener/blob/b5e4b574ddd1c2f60b6c98b5513d0157ab9482d4/internal/app/shortener/app.go#L75-L81

**Инкремент 22:**
Добавил поддержку загрузки конфигурации через файл `config.json`. По условию такая конфигурация имеет низший приоритет перед флагами и переменными окружения
https://github.com/msmkdenis/yap-shortener/blob/b5e4b574ddd1c2f60b6c98b5513d0157ab9482d4/internal/config/config.go#L57-L61

**Инкремент 23:**
Echo поддерживает grace shutdown, он у меня уже давно был реализован.
Добавил еще свое понимание grace shutdown воркеров из пула, который асинхронно удаляли урлы пользователя. Реализовал через waitgroup: дожидаюсь выполнения воркеров.
https://github.com/msmkdenis/yap-shortener/blob/b5e4b574ddd1c2f60b6c98b5513d0157ab9482d4/internal/handlers/url_handler.go#L140-L149
Жду в функции запуска всего приложения.
Передаю wg  в хендлер
https://github.com/msmkdenis/yap-shortener/blob/b5e4b574ddd1c2f60b6c98b5513d0157ab9482d4/internal/app/shortener/app.go#L46-L47
Жду окончания
https://github.com/msmkdenis/yap-shortener/blob/b5e4b574ddd1c2f60b6c98b5513d0157ab9482d4/internal/app/shortener/app.go#L90

